### PR TITLE
Change to link matching regex to handle specific case

### DIFF
--- a/lib/Mailnesia/Email.pm
+++ b/lib/Mailnesia/Email.pm
@@ -64,7 +64,7 @@ my $click = qr"confirm|
                signup|
                soundcloud.com/emails/|
                mail.google.com/mail/vf-|
-               \bcheck\b|
+               \b[Cc]heck\b|
                wqrw/podziekowania\?id=\d+&key=[a-z0-9]+|
                \bact\b|
                yify-torrents.com/[a-z0-9]+"ix;


### PR DESCRIPTION
Attempting to change the link matching regex to match to link text that says "blah blah blah Check In.".  It currently is not clicked by the service, and I believe it is because the regex doesn't match to the capital C in the link text.  Note that this is NOT in the URL itself, so if I am misunderstanding how the matching algorithm works this change might not make any sense.